### PR TITLE
Supporting Windows in 2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This application is written in the latest version of Python, currently 3.8.  It 
 available on [PyPI](pypi.org/), except the converter application described below.
 
 To convert from HTML to MOBI, it requires the [KindleGen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211), or the [Calibre](https://calibre-ebook.com/)
-applications.  Either application must be dowloaded and installed separately.
+applications.  Either application must be dowloaded and installed separately. Since writing this package KindleGen is no longer supported (2022-01-06), so use Calibre.
 
 As KindleGen is not supported on MacOS Catalina or newer, for this platform you must use Calibre.
 
@@ -38,8 +38,9 @@ To use this application:
 * Install the Python dependencies from PyPI
     * `pip3 install -r requirements.txt`
 * Install the converter application (Kindlegen or Calibre) according to the
-vendor's instructions (see above).
-* Run this application as `python3 main.py`
+vendor's instructions (see above). Note that when running this package
+ on Windows the default converter application is Kindlegen, which can be changed via a command line argument to Calibre (see below).
+* Run this application as `python3 main.py` or `python main.py --calibre "C:\Program Files (x86)\Calibre2\ebook-convert.exe" --mobi_converter calibre` if you wish to specify the path to the calibre install location and force to use calibre (for example, on windows to overwrite the default).
 
 ## Bug Reports
 Please submit bug reports or pull requests through GitHub.

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Use of the application must conform to [The Economist's terms of use](https://ww
 This application is written in the latest version of Python, currently 3.8.  It uses no libraries not
 available on [PyPI](pypi.org/), except the converter application described below.
 
-To convert from HTML to MOBI, it requires the [KindleGen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211), or the [Calibre](https://calibre-ebook.com/)
-applications.  Either application must be dowloaded and installed separately. Since writing this package KindleGen is no longer supported (2022-01-06), so use Calibre.
+This application was originally built to convert from HTML to MOBI, it requires the [KindleGen](https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211), or the [Calibre](https://calibre-ebook.com/)
+applications.  Either application must be dowloaded and installed separately. Since writing this package KindleGen is no longer supported (2022-01-06), so use Calibre. Also since writing Amazon announced they will no longer support .mobi, but will add support for epubs.
 
 As KindleGen is not supported on MacOS Catalina or newer, for this platform you must use Calibre.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ To use this application:
 vendor's instructions (see above). Note that when running this package
  on Windows the default converter application is Kindlegen, which can be changed via a command line argument to Calibre (see below).
 * Run this application as `python3 main.py` or `python main.py --calibre "C:\Program Files (x86)\Calibre2\ebook-convert.exe" --mobi_converter calibre` if you wish to specify the path to the calibre install location and force to use calibre (for example, on windows to overwrite the default).
+    * To use the functionality that auto sends an email to your kindle, `D:\my_user\git\econokindle\venv\Scripts\python.exe D:\my_user\git\econokindle\main.py --calibre "C:\Program Files (x86)\Calibre2\ebook-convert.exe" --mobi_converter calibre --to_email fake_email@kindle.com --from_email fake_email@gmail.com --password_email fake_pass --send_email true`
+    * Note that the from email if using gmail needs an app specific password enabled, and the from email needs to be added to the approved list of senders to the kindle, and the to email must be your unique kindle email address.
+    * This can also be scheduled, for instance from TaskScheduler on Windows.
 
 ## Bug Reports
 Please submit bug reports or pull requests through GitHub.

--- a/econokindle/EmailKindle.py
+++ b/econokindle/EmailKindle.py
@@ -1,0 +1,38 @@
+import smtplib
+import os
+from email.mime.application import MIMEApplication
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.utils import COMMASPACE, formatdate
+
+
+def send_mail(send_from, gmail_password: str, send_to, subject, text, files=None,
+              server="smtp.gmail.com", port=587):
+    assert isinstance(send_to, list)
+    print("emailing edition")
+    msg = MIMEMultipart()
+    msg['From'] = send_from
+    msg['To'] = COMMASPACE.join(send_to)
+    msg['Cc'] = COMMASPACE.join([send_from])
+    msg['Date'] = formatdate(localtime=True)
+    msg['Subject'] = subject
+
+    msg.attach(MIMEText(text))
+
+    for f in files or []:
+        print(f)
+        with open(f, "rb") as fil:
+            part = MIMEApplication(
+                fil.read(),
+                Name=os.path.basename(f)
+            )
+        # After the file is closed
+        part['Content-Disposition'] = 'attachment; filename="%s"' % os.path.basename(f)
+        msg.attach(part)
+
+    smtp = smtplib.SMTP(server, port)
+    smtp.ehlo()
+    smtp.starttls()  # enable security
+    smtp.login(send_from, gmail_password)
+    smtp.sendmail(send_from, send_to, msg.as_string())
+    smtp.close()

--- a/econokindle/Fetcher.py
+++ b/econokindle/Fetcher.py
@@ -1,6 +1,6 @@
 import logging
 import time
-
+import os
 from requests import Session
 
 from econokindle.Cache import Cache
@@ -42,7 +42,9 @@ class Fetcher:
                 image = response.content
             else:
                 _log.warning(f"Unable to fetch image {url}, using default.")
-                with open('resources/default.png', 'rb') as inimage:
+                fetcher_location = os.path.dirname(os.path.abspath(__file__))
+                default_img_path = os.path.join(fetcher_location, "..", "resources", "default.png")
+                with open(default_img_path, 'rb') as inimage:
                     image = inimage.read()
             self.__cache.store(url, image)
         return image

--- a/econokindle/platform.py
+++ b/econokindle/platform.py
@@ -9,8 +9,8 @@ ConversionCommand = Optional[List[str]]
 
 
 def load_to_kindle(work: str, issue: dict) -> None:
-    cached_name = work + 'economist.mobi'
-    cached_edition_name = work + issue['edition'] + '_economist.mobi'
+    cached_name = os.path.join(work, 'economist.mobi')
+    cached_edition_name = os.path.join(work, issue['edition'] + '_economist.mobi')
     root = 'D:/documents/' if _is_windows() else '/Volumes/Kindle/documents/'
     target_name = root + issue['edition'] + '_economist.mobi'
     os.rename(cached_name, cached_edition_name)

--- a/econokindle/platform.py
+++ b/econokindle/platform.py
@@ -9,10 +9,10 @@ ConversionCommand = Optional[List[str]]
 
 
 def load_to_kindle(work: str, issue: dict) -> None:
-    cached_name = os.path.join(work, 'economist.mobi')
-    cached_edition_name = os.path.join(work, issue['edition'] + '_economist.mobi')
+    cached_name = os.path.join(work, 'economist.epub')
+    cached_edition_name = os.path.join(work, issue['edition'] + '_economist.epub')
     root = 'D:/documents/' if _is_windows() else '/Volumes/Kindle/documents/'
-    target_name = root + issue['edition'] + '_economist.mobi'
+    target_name = root + issue['edition'] + '_economist.epub'
     os.rename(cached_name, cached_edition_name)
     print("File renamed to: " + cached_edition_name)
     if os.path.isdir(root):
@@ -23,7 +23,7 @@ def _is_windows() -> bool:
     return platform.system() == 'Windows'
 
 
-def convert_to_mobi(args: argparse.Namespace, path: str) -> None:
+def convert_to_epub(args: argparse.Namespace, path: str) -> None:
     """ Assumes that kindlegen is used on Windows, and Calibre on MacOS.  This
         whole converter selection is a bit smelly, and should probably be heavily
         refactored.   Some other day. """
@@ -41,7 +41,7 @@ def convert_to_mobi(args: argparse.Namespace, path: str) -> None:
                                " like Calibre or KindleGen installed as per the README?"
     if completed_process.returncode != 0:
         raise Exception(conversion_exception_str)
-    if not os.path.isfile(os.path.join(path, 'economist.mobi')):
+    if not os.path.isfile(os.path.join(path, 'economist.epub')):
         raise Exception("Output file not found. " + conversion_exception_str)
 
 
@@ -52,7 +52,7 @@ def _calibre(args: argparse.Namespace) -> ConversionCommand:
         if not os.path.isfile(binary) and not binary.endswith('/ebook-convert'):
             return None
     return [
-        binary, 'economist.html', 'economist.mobi',
+        binary, 'economist.html', 'economist.epub',
         '--max-toc-links=250', '--page-breaks-before=/', '--verbose', '--disable-markup-chapter-headings',
         '--chapter=/', '--prefer-metadata-cover',
         '--no-chapters-in-toc', '--cover=cover.jpg', '--authors=Economist',

--- a/main.py
+++ b/main.py
@@ -31,6 +31,14 @@ def parse_args():
         '-c', '--calibre', default='/Applications/calibre.app/Contents/MacOS/ebook-convert',
         help='Path to "calibre" binary.  Defaults to /Applications/calibre.app/Contents/MacOS/ebook-convert'
     )
+    parser.add_argument(
+        '-m', '--mobi_converter', default='system_default',
+        choices=['kindlegen', 'calibre', 'system_default'],
+        help='Converter application to use to convert the html file into a MOBI file. The application to use must be pre-installed on your computer.'
+             ' Options are "kindlegen" which will use Amazon KindleGen, '
+             '"calibre" which will use the open source Calibre application, '
+             'or "system_default" which will use kindlegen when on windows, and calibre when on Mac.'
+    )
     return parser.parse_args()
 
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import sqlite3
 from shutil import copyfile
-
+import logging
 import requests
 from jinja2 import Environment, FileSystemLoader
 
@@ -15,11 +15,13 @@ from econokindle.IndexParser import IndexParser
 from econokindle.KeyCreator import KeyCreator
 from econokindle.cache.SqliteCache import SqliteCache
 from econokindle.platform import load_to_kindle, convert_to_mobi
+from econokindle.EmailKindle import send_mail
 
-WORK = './work/'
-RESOURCES = 'resources'
+MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
+WORK = os.path.join(MAIN_DIR, "work")
+RESOURCES = os.path.join(MAIN_DIR, 'resources')
 env = Environment(loader=FileSystemLoader(RESOURCES), autoescape=False)
-
+_logger = logging.getLogger(__name__)
 
 def parse_args():
     parser = argparse.ArgumentParser()
@@ -39,24 +41,69 @@ def parse_args():
              '"calibre" which will use the open source Calibre application, '
              'or "system_default" which will use kindlegen when on windows, and calibre when on Mac.'
     )
+    parser.add_argument(
+        '-t', '--to_email', default=None, type=str,
+        help='Address to send an email to when using --send_email'
+    )
+    parser.add_argument(
+        '-f', '--from_email', default=None, type=str,
+        help='Address to send an email from when using --send_email'
+    )
+    parser.add_argument(
+        '-p', '--password_email', default=None, type=str,
+        help='Password (app specific password) to send an email with.'
+    )
+
+    parser.add_argument(
+        '-s', '--send_email', default=False, type=bool,
+        help='If true, will try to email the economist edition to the given to email address, using the from address.'
+    )
+
     return parser.parse_args()
 
 
+def setup_logger(logger):
+    logger.setLevel(logging.INFO)
+    # create console handler and set level to debug
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    # create formatter
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    # add formatter to ch
+    ch.setFormatter(formatter)
+    # add ch to logger
+    logger.addHandler(ch)
+
+    fh = logging.FileHandler(os.path.join(WORK, "econologger.log"))
+    fh.setLevel(logging.INFO)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+
+
 async def process_issue(fetcher: Fetcher, key_creator: KeyCreator, args: argparse.Namespace) -> None:
+    setup_logger(_logger)
+    _logger.info("processing issue")
     issue_url = 'https://www.economist.com/printedition'
     print(f'Processing {issue_url}...', end='')
     issue = IndexParser(fetcher.fetch_page(issue_url), key_creator).parse()
     cover_image = fetcher.fetch_image(issue['cover_image_url'])
-    with open(f'{WORK}cover.jpg', 'wb') as out:
+    with open(os.path.join(WORK, "cover.jpg"), 'wb') as out:
         out.write(cover_image)
     print('done.')
+    _logger.info("processing articles")
     await process_articles_in_issue(fetcher, key_creator, issue)
     add_section_links(issue)
     render(issue)
-    copyfile(RESOURCES + '/style.css', WORK + 'style.css')
+    copyfile(os.path.join(RESOURCES, 'style.css'), os.path.join(WORK, 'style.css'))
+    _logger.info("converting to mobi")
     convert_to_mobi(args, WORK)
     load_to_kindle(WORK, issue)
-
+    if args.send_email:
+        _logger.info("sending email")
+        send_mail(args.from_email, args.password_email, [args.to_email],
+                  "economist weekly edition", "heres the weekly edition",
+                  files=[os.path.join(WORK, issue['edition'] + '_economist.mobi')])
+    _logger.info("done")
 
 async def process_articles_in_issue(fetcher: Fetcher, key_creator: KeyCreator, issue: dict) -> None:
     for url in issue['urls']:
@@ -78,7 +125,7 @@ async def process_article_content(article_content, issue, key_creator):
 def fetch_article_images(article, fetcher, key_creator):
     for image_url in article['images']:
         image = fetcher.fetch_image(image_url)
-        with open(WORK + key_creator.key(image_url).lower(), 'wb') as out:
+        with open(os.path.join(WORK, key_creator.key(image_url).lower()), 'wb') as out:
             out.write(image)
 
 
@@ -115,7 +162,7 @@ def render(issue: dict) -> None:
 def render_template(template: str, file: str, issue: dict) -> None:
     sections = issue['sections']
     content = env.get_template(template).render(sections=sections, title=issue['title'], issue=issue)
-    with open(WORK + file, 'wt') as writer:
+    with open(os.path.join(WORK, file), 'wt') as writer:
         writer.write(content)
 
 

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from econokindle.Fetcher import Fetcher
 from econokindle.IndexParser import IndexParser
 from econokindle.KeyCreator import KeyCreator
 from econokindle.cache.SqliteCache import SqliteCache
-from econokindle.platform import load_to_kindle, convert_to_mobi
+from econokindle.platform import load_to_kindle, convert_to_epub
 from econokindle.EmailKindle import send_mail
 
 MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -96,13 +96,13 @@ async def process_issue(fetcher: Fetcher, key_creator: KeyCreator, args: argpars
     render(issue)
     copyfile(os.path.join(RESOURCES, 'style.css'), os.path.join(WORK, 'style.css'))
     _logger.info("converting to mobi")
-    convert_to_mobi(args, WORK)
+    convert_to_epub(args, WORK)
     load_to_kindle(WORK, issue)
     if args.send_email:
         _logger.info("sending email")
         send_mail(args.from_email, args.password_email, [args.to_email],
                   "economist weekly edition", "heres the weekly edition",
-                  files=[os.path.join(WORK, issue['edition'] + '_economist.mobi')])
+                  files=[os.path.join(WORK, issue['edition'] + '_economist.epub')])
     _logger.info("done")
 
 async def process_articles_in_issue(fetcher: Fetcher, key_creator: KeyCreator, issue: dict) -> None:


### PR DESCRIPTION
This is a nice package. Thanks for writing it.

I tried to use it today on windows and ran into some trouble. Firstly that KindleGen isnt supported anymore (clicking the link takes me to a landing page with a message saying its no longer supported and recommending KindlePreviewer), and second that the package on Windows defaults to KindleGen. I figured easiest is to add an argument that can force which app to use to convert, and the default behavior is to use the system default methodology from earlier. In case other folks are using this package on windows, and have been for awhile, and have KindleGen installed, they shouldn't be impacted by these changes as we default to the prior behavior.

So to sum up the changes:
Adding a command line argument that can force the choice of converter application, instead of defaulting to KindleGen on windows and Calibre on MAC. Default for the arg is to keep the same behavior as previously though.

Adding some error handling around the subprocess that generates the Mobi, and some more clear error messages indicating what is going on if the conversion fails or a binary cant be found.

Updated the documentation to add some notes to reflect that KindleGen is no longer supported and to give instructions on how to force Calibre on Windows.